### PR TITLE
Update typescript to v6

### DIFF
--- a/packages/apollo-core/package.json
+++ b/packages/apollo-core/package.json
@@ -17,7 +17,7 @@
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
     "tslib": "2.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "homepage": "https://inversify.io/framework/",

--- a/packages/apollo-core/tsconfig.esm.json
+++ b/packages/apollo-core/tsconfig.esm.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./lib/esm",
     "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/apollo-core/tsconfig.json
+++ b/packages/apollo-core/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@inversifyjs/foundation-typescript-config/tsconfig.base.esm.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
-  "include": ["src"]
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/apollo-express/package.json
+++ b/packages/apollo-express/package.json
@@ -18,7 +18,7 @@
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
     "tslib": "2.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "homepage": "https://inversify.io/framework/",

--- a/packages/apollo-express/tsconfig.esm.json
+++ b/packages/apollo-express/tsconfig.esm.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./lib/esm",
     "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/apollo-express/tsconfig.json
+++ b/packages/apollo-express/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@inversifyjs/foundation-typescript-config/tsconfig.base.esm.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
-  "include": ["src"]
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/apollo-fastify/package.json
+++ b/packages/apollo-fastify/package.json
@@ -18,7 +18,7 @@
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
     "tslib": "2.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "homepage": "https://inversify.io/framework/",

--- a/packages/apollo-fastify/tsconfig.esm.json
+++ b/packages/apollo-fastify/tsconfig.esm.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./lib/esm",
     "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/apollo-fastify/tsconfig.json
+++ b/packages/apollo-fastify/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@inversifyjs/foundation-typescript-config/tsconfig.base.esm.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
-  "include": ["src"]
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/apollo-subscription-ws/package.json
+++ b/packages/apollo-subscription-ws/package.json
@@ -26,7 +26,7 @@
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
     "tslib": "2.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "homepage": "https://inversify.io/framework/",

--- a/packages/apollo-subscription-ws/tsconfig.esm.json
+++ b/packages/apollo-subscription-ws/tsconfig.esm.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./lib/esm",
     "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/apollo-subscription-ws/tsconfig.json
+++ b/packages/apollo-subscription-ws/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@inversifyjs/foundation-typescript-config/tsconfig.base.esm.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
-  "include": ["src"]
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -18,7 +18,7 @@
     "eslint": "10.2.1",
     "rimraf": "6.1.3",
     "tslib": "2.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "homepage": "https://inversify.io/framework/",

--- a/packages/codegen/tsconfig.esm.json
+++ b/packages/codegen/tsconfig.esm.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./lib/esm",
     "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@inversifyjs/foundation-typescript-config/tsconfig.base.esm.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
-  "include": ["src"]
+  "extends": "./tsconfig.esm.json"
 }


### PR DESCRIPTION
### Changed
- Updated typescript to version 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated TypeScript compiler from version 5.9.3 to 6.0.3 across multiple development packages to leverage the latest compiler improvements and language features.
* Consolidated build configuration by reorganizing package-specific compiler settings into a unified, centralized base configuration, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->